### PR TITLE
fix: Type args error in SimpleMavConnection

### DIFF
--- a/api/src/main/kotlin/xyz/urbanmatrix/mavlink/api/MavFrame.kt
+++ b/api/src/main/kotlin/xyz/urbanmatrix/mavlink/api/MavFrame.kt
@@ -6,7 +6,7 @@ package xyz.urbanmatrix.mavlink.api
  *
  * @param <T> The type of this frame's payload.
 </T> */
-interface MavFrame<T : MavMessage<T>> {
+interface MavFrame<T> {
     /**
      * The sequence of this frame.
      */

--- a/api/src/main/kotlin/xyz/urbanmatrix/mavlink/api/MavFrameV1.kt
+++ b/api/src/main/kotlin/xyz/urbanmatrix/mavlink/api/MavFrameV1.kt
@@ -1,3 +1,3 @@
 package xyz.urbanmatrix.mavlink.api
 
-interface MavFrameV1<T : MavMessage<T>> : MavFrame<T>
+interface MavFrameV1<T> : MavFrame<T>

--- a/api/src/main/kotlin/xyz/urbanmatrix/mavlink/api/MavFrameV2.kt
+++ b/api/src/main/kotlin/xyz/urbanmatrix/mavlink/api/MavFrameV2.kt
@@ -1,6 +1,6 @@
 package xyz.urbanmatrix.mavlink.api
 
-interface MavFrameV2<T : MavMessage<T>> : MavFrame<T> {
+interface MavFrameV2<T> : MavFrame<T> {
     /**
      * Flag to check if the frame is signed or not.
      */

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ task("publishPlugin") {
     dependsOn(
         ":api:publish",
         ":serialization:publish",
-        ":generator:publish",
+        ":generator:publishPlugins",
     )
 }
 

--- a/buildSrc/src/main/kotlin/ProjectSpecs.kt
+++ b/buildSrc/src/main/kotlin/ProjectSpecs.kt
@@ -2,11 +2,11 @@ object Specs {
     const val group = "xyz.urbanmatrix.mavlink"
 
     object Plugin {
-        const val releaseVersion = "0.4.3"
-        const val developmentVersion = "0.4.4"
+        const val releaseVersion = "0.4.4"
+        const val developmentVersion = "0.4.5"
     }
 
     object Lib {
-        const val developmentVersion = "0.4.4"
+        const val developmentVersion = "0.4.5"
     }
 }

--- a/mavlink-kotlin/src/main/kotlin/xyz/urbanmatrix/mavlink/connection/SimpleMavConnection.kt
+++ b/mavlink-kotlin/src/main/kotlin/xyz/urbanmatrix/mavlink/connection/SimpleMavConnection.kt
@@ -38,7 +38,6 @@ class SimpleMavConnection(
         connectionHandle.close()
     }
 
-    @Suppress("TYPE_MISMATCH_WARNING", "UPPER_BOUND_VIOLATED_WARNING")
     @Throws(IOException::class)
     override fun next(): MavFrame<out MavMessage<*>> {
         readLock.withLock {
@@ -60,8 +59,8 @@ class SimpleMavConnection(
                 }
 
                 return when (rawFrame.stx) {
-                    MavFrameType.V1.magic -> MavFrameV1Impl<MavMessage<*>>(rawFrame, payload)
-                    MavFrameType.V2.magic -> MavFrameV2Impl<MavMessage<*>>(rawFrame, payload)
+                    MavFrameType.V1.magic -> MavFrameV1Impl(rawFrame, payload)
+                    MavFrameType.V2.magic -> MavFrameV2Impl(rawFrame, payload)
                     else -> throw IllegalStateException()
                 }
             }

--- a/mavlink-kotlin/src/main/kotlin/xyz/urbanmatrix/mavlink/frame/MavFrameV1Impl.kt
+++ b/mavlink-kotlin/src/main/kotlin/xyz/urbanmatrix/mavlink/frame/MavFrameV1Impl.kt
@@ -1,10 +1,9 @@
 package xyz.urbanmatrix.mavlink.frame
 
 import xyz.urbanmatrix.mavlink.api.MavFrameV1
-import xyz.urbanmatrix.mavlink.api.MavMessage
 import xyz.urbanmatrix.mavlink.raw.MavRawFrame
 
-data class MavFrameV1Impl<T : MavMessage<T>>(
+data class MavFrameV1Impl<T>(
     private val rawFrame: MavRawFrame,
     override val message: T
 ) : MavFrameV1<T> {

--- a/mavlink-kotlin/src/main/kotlin/xyz/urbanmatrix/mavlink/frame/MavFrameV2Impl.kt
+++ b/mavlink-kotlin/src/main/kotlin/xyz/urbanmatrix/mavlink/frame/MavFrameV2Impl.kt
@@ -1,10 +1,9 @@
 package xyz.urbanmatrix.mavlink.frame
 
 import xyz.urbanmatrix.mavlink.api.MavFrameV2
-import xyz.urbanmatrix.mavlink.api.MavMessage
 import xyz.urbanmatrix.mavlink.raw.MavRawFrame
 
-data class MavFrameV2Impl<T : MavMessage<T>>(
+data class MavFrameV2Impl<T>(
     private val rawFrame: MavRawFrame,
     override val message: T
 ) : MavFrameV2<T> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
         }
     }
     plugins {
-        kotlin("jvm") version "1.7.10"
+        kotlin("jvm") version "1.6.20"
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
         }
     }
     plugins {
-        kotlin("jvm") version "1.6.20"
+        kotlin("jvm") version "1.7.10"
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ rootProject.name = "mavlink-kotlin-root"
 include(":api")
 include(":serialization")
 include(":generator")
+
 include(":definitions")
 include(":mavlink-kotlin")
 


### PR DESCRIPTION
How `MavFrame` was defined caused upper bound violation error when deserializing from the input stream. This problem somehow did not result in a compilation error in the case of Kotlin-1.6.20 but somehow appeared in Kotlin-1.7.10

`MavFrame` and its derivatives are now defined as `MavFrame<T>` instead of `MavFrame<T : MavMessage<T>>`.