### PR TITLE
feat: Added Builder generation code

### DIFF
--- a/generator/src/main/kotlin/xyz/urbanmatrix/mavlink/generator/FieldGen.kt
+++ b/generator/src/main/kotlin/xyz/urbanmatrix/mavlink/generator/FieldGen.kt
@@ -12,9 +12,15 @@ fun FieldModel.generateConstructorParameter(enumResolver: EnumResolver) = Parame
     .apply { if (content != null) addKdoc(content!!.replace("%", "%%")) }
     .build()
 
-fun FieldModel.generateProperty(enumResolver: EnumResolver) = PropertySpec
+fun FieldModel.generateConstructorProperty(enumResolver: EnumResolver) = PropertySpec
     .builder(formattedName, resolveKotlinType(enumResolver))
     .initializer(formattedName)
+    .build()
+
+fun FieldModel.generateBuilderProperty(enumResolver: EnumResolver) = PropertySpec
+    .builder(formattedName, resolveKotlinType(enumResolver))
+    .mutable()
+    .initializer(defaultKotlinValue)
     .build()
 
 private fun FieldModel.resolveKotlinType(enumResolver: EnumResolver): TypeName = when (this) {

--- a/generator/src/main/kotlin/xyz/urbanmatrix/mavlink/generator/MessageGen.kt
+++ b/generator/src/main/kotlin/xyz/urbanmatrix/mavlink/generator/MessageGen.kt
@@ -48,6 +48,7 @@ private fun MessageModel.generateCompanionObject(packageName: String) = TypeSpec
     .addProperty(generateDeserializer(packageName))
     .addProperty(generateMetadataProperty(packageName))
     .addProperty(generateClassMetadata(packageName))
+    .addFunction(generateBuilderFunction(packageName))
     .build()
 
 private fun MessageModel.generateGeneratedAnnotation() = AnnotationSpec
@@ -160,6 +161,11 @@ private fun MessageModel.generateBuildMethod(packageName: String) = FunSpec.buil
             add(")")
         }
     )
+    .build()
+
+private fun MessageModel.generateBuilderFunction(packageName: String) = FunSpec.builder("builder")
+    .addParameter(ParameterSpec("builderAction", LambdaTypeName.get(getClassName(packageName).nestedClass("Builder"), emptyList(), Unit::class.asTypeName())))
+    .addCode("return %T().apply(builderAction).build()", getClassName(packageName).nestedClass("Builder"))
     .build()
 
 private val MessageModel.size: Int

--- a/generator/src/main/kotlin/xyz/urbanmatrix/mavlink/generator/MessageGen.kt
+++ b/generator/src/main/kotlin/xyz/urbanmatrix/mavlink/generator/MessageGen.kt
@@ -17,7 +17,7 @@ fun MessageModel.generateMessageFile(packageName: String, enumResolver: EnumReso
         .addModifiers(KModifier.DATA)
         .addSuperinterface(MavMessage::class.asClassName().parameterizedBy(getClassName(packageName)))
         .primaryConstructor(generatePrimaryConstructor(enumResolver))
-        .apply { fields.sortedByPosition().forEach { addProperty(it.generateProperty(enumResolver)) } }
+        .apply { fields.sortedByPosition().forEach { addProperty(it.generateConstructorProperty(enumResolver)) } }
         .apply {
             if (deprecated != null) addAnnotation(deprecated.generateAnnotation())
             if (workInProgress) addAnnotation(WorkInProgress::class)
@@ -27,6 +27,7 @@ fun MessageModel.generateMessageFile(packageName: String, enumResolver: EnumReso
         .addProperty(generateInstanceMetadata(packageName))
         .addFunction(generateSerialize())
         .addType(generateCompanionObject(packageName))
+        .addType(generateBuilderClass(enumResolver))
         .build()
 
     return FileSpec.builder(packageName, formattedName)
@@ -141,6 +142,10 @@ private fun MessageModel.generateSerialize() = FunSpec
             addStatement("return outputBuffer.array()")
         }
     )
+    .build()
+
+private fun MessageModel.generateBuilderClass(enumResolver: EnumResolver) = TypeSpec.classBuilder("Builder")
+    .apply { fields.sortedByPosition().forEach { addProperty(it.generateBuilderProperty(enumResolver)) } }
     .build()
 
 private val MessageModel.size: Int


### PR DESCRIPTION
Using the constructor was the only way to create a mavlink message object, that wasn't a flexible API. So we added a Builder generation code that will create a Builder class or function in the companion object of the mavlink messages.

We can now create mavlink message objects using the nested Builder class:

```
val b = Altitude.Builder()
b.altitudeAmsl = 10F
b.altitudeRelative = 20F
val altitude = b.build()
```

Or we can even use the builder function as follows:

```
val altitude = Altitude.builder {
  altitudeAmsl = 10F
  altitudeRelative = 20F
}
```