### PR TITLE
Use CoroutineContext instead of CoroutineDispatcher

### DIFF
--- a/adapters/adapter-coroutines/src/main/kotlin/com/divpundir/mavlink/adapters/coroutines/CoroutinesExtensions.kt
+++ b/adapters/adapter-coroutines/src/main/kotlin/com/divpundir/mavlink/adapters/coroutines/CoroutinesExtensions.kt
@@ -2,24 +2,24 @@ package com.divpundir.mavlink.adapters.coroutines
 
 import com.divpundir.mavlink.api.MavMessage
 import com.divpundir.mavlink.connection.MavConnection
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import okio.IOException
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A helper function to wrap a [MavConnection] as a [CoroutinesMavConnection]. The returned [CoroutinesMavConnection]
- * uses the provided [dispatcher] to perform the IO operations of reading and sending the messages. The [onFailure]
+ * uses the provided [context] to perform the IO operations of reading and sending the messages. The [onFailure]
  * callback is invoked when an exception is thrown while reading the messages. This can be used to implement a custom
  * reconnection strategy.
  */
 public fun MavConnection.asCoroutine(
-    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    context: CoroutineContext = Dispatchers.IO,
     onFailure: CoroutinesMavConnection.() -> Unit = {}
 ): CoroutinesMavConnection = CoroutinesMavConnectionImpl(
     connection = this,
-    dispatcher = dispatcher,
+    context = context,
     extraBufferCapacity = 128,
     onBufferOverflow = BufferOverflow.DROP_OLDEST,
     onFailure = onFailure


### PR DESCRIPTION
This is useful for me because I have a use case where I'm passing around `CoroutineContext` rather than `CoroutineDispatcher`, but here you're only using them for calls to `withContext` - which works exactly the same since we're now just using the base interface instead.

Love the library by the way, extremely useful.